### PR TITLE
bootstrap.sh - fix sql script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,6 +8,7 @@ debconf-set-selections <<< 'mysql-server mysql-server/root_password_again passwo
 # Installing packages
 apt-get install -y python3-pip mysql-server mysql-client
 # create database
+systemctl start mysql
 mysql -u root -proot  <<MYSQL_SCRIPT
 CREATE DATABASE baboon;
 USE baboon;


### PR DESCRIPTION
fix #99 

That's supposed to work.

EDIT: CI passed, it works. :) 



BTW Seems like It's a new problem in GH actions, from last march:
https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/